### PR TITLE
Typo Fixes & Remove __builtin_bswap8

### DIFF
--- a/isotp.c
+++ b/isotp.c
@@ -117,7 +117,7 @@ static int isotp_send_consecutive_frame(IsoTpLink* link) {
     assert(link->send_size > 7);
 
     /* setup message  */
-    message.as.consecutive_frame.type = TSOTP_PCI_TYPE_CONSECUTIVE_FRAME;
+    message.as.consecutive_frame.type = ISOTP_PCI_TYPE_CONSECUTIVE_FRAME;
     message.as.consecutive_frame.SN = link->send_sn;
     data_length = link->send_size - link->send_offset;
     if (data_length > sizeof(message.as.consecutive_frame.data)) {
@@ -348,7 +348,7 @@ void isotp_on_can_message(IsoTpLink *link, uint8_t *data, uint8_t len) {
             
             break;
         }
-        case TSOTP_PCI_TYPE_CONSECUTIVE_FRAME: {
+        case ISOTP_PCI_TYPE_CONSECUTIVE_FRAME: {
             /* check if in receiving status */
             if (ISOTP_RECEIVE_STATUS_INPROGRESS != link->receive_status) {
                 link->receive_protocol_result = ISOTP_PROTOCOL_RESULT_UNEXP_PDU;

--- a/isotp_defines.h
+++ b/isotp_defines.h
@@ -22,7 +22,6 @@
 
 #ifdef _WIN32
 #define ISOTP_BYTE_ORDER_LITTLE_ENDIAN
-#define __builtin_bswap8  _byteswap_uint8
 #define __builtin_bswap16 _byteswap_uint16
 #define __builtin_bswap32 _byteswap_uint32
 #define __builtin_bswap64 _byteswap_uint64

--- a/isotp_defines.h
+++ b/isotp_defines.h
@@ -196,7 +196,7 @@ typedef struct {
 typedef enum {
     ISOTP_PCI_TYPE_SINGLE             = 0x0,
     ISOTP_PCI_TYPE_FIRST_FRAME        = 0x1,
-    TSOTP_PCI_TYPE_CONSECUTIVE_FRAME  = 0x2,
+    ISOTP_PCI_TYPE_CONSECUTIVE_FRAME  = 0x2,
     ISOTP_PCI_TYPE_FLOW_CONTROL_FRAME = 0x3
 } IsoTpProtocolControlInformation;
 


### PR DESCRIPTION
1. typo fix `TSOTP_PCI_TYPE_CONSECUTIVE_FRAME` now is `ISOTP_PCI_TYPE_CONSECUTIVE_FRAME`
2. one byte don't need swap and gcc don't have built in function `__builtin_bswap8`